### PR TITLE
Use full width for custom-range input

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -15801,7 +15801,7 @@ a.tag-addon:hover {
 }
 
 .custom-range::-moz-range-track {
-  width: 240px;
+  width: 100%;
   height: 2px;
   background: rgba(0, 50, 126, 0.12);
 }
@@ -15832,7 +15832,7 @@ a.tag-addon:hover {
   color: transparent;
   height: 2px;
   margin-top: 10px;
-  width: 240px;
+  width: 100%;
 }
 
 .custom-range::-ms-thumb {


### PR DESCRIPTION
Should fix `custom-range` width in Firefox (and Internet explorer?)

Before
![image](https://github.com/user-attachments/assets/86bc376e-a2d6-45eb-a44c-6db06154a938)

After
![image](https://github.com/user-attachments/assets/069388d1-3719-4001-b263-577d27409ee2)
